### PR TITLE
feat(Formatters): Added valueFormatter to differentiate the formattin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,20 @@ Mixpanel recommmend to use human names for action types and properties. You can 
 ## Action Types
 
 ```
-mixpanelMiddleware(token, {actionTypeFormatter: value => `---${value}---`}); // event will look like '---Action---'
+mixpanelMiddleware(token, {actionTypeFormatter: actionType => `---${actionType}---`}); // event will look like '---Action---'
 ```
 
 ## Properties and Increment name
 
 ```
-mixpanelMiddleware(token, {propertyFormatter: value => `---${value}---`}); // mixpanel custom properties will look like '---Action---'
+mixpanelMiddleware(token, {propertyFormatter: property => `---${property}---`}); // mixpanel custom properties will look like '---Property---'
 ```
+
+## Values
+```
+mixpanelMiddleware(token, {valueFormatter: value => `---${value}---`}); // mixpanel custom properties will look like '---Value---'
+```
+
 
 # Redux Actions
 

--- a/src/mixpanelMiddleware.js
+++ b/src/mixpanelMiddleware.js
@@ -2,9 +2,9 @@ import mixpanel from 'mixpanel-browser';
 
 const identity = value => value;
 
-const renameProperties = (object, formatter) => {
+const renameEventData = (object, propFormatter, valFormatter) => {
     return Object.keys(object).reduce((memo, key) => {
-        memo[formatter(key)] = formatter(object[key]);
+        memo[propFormatter(key)] = valFormatter(object[key]);
         return memo;
     }, {})
 };
@@ -17,6 +17,7 @@ export default function mixpanelMiddleware(token, options = {}) {
         uniqueIdSelector,
         actionTypeFormatter = identity,
         propertyFormatter = identity,
+        valueFormatter = identity,
     } = options;
 
     return store => next => action => {
@@ -42,7 +43,7 @@ export default function mixpanelMiddleware(token, options = {}) {
 
             const data = (typeof mixpanelPayload === 'object') ? mixpanelPayload : {};
             mixpanel.track(actionTypeFormatter(eventName), {
-                ...renameProperties(data, propertyFormatter),
+                ...renameEventData(data, propertyFormatter, valueFormatter),
                 action: actionTypeFormatter(customType || type),
             });
         }

--- a/test/mixpanelMiddleware.tests.js
+++ b/test/mixpanelMiddleware.tests.js
@@ -12,7 +12,6 @@ describe('mixpanelMiddleware', () => {
             const {
                 auth: {
                     user: {
-                        id,
                         username,
                         firstName,
                         lastName,
@@ -264,6 +263,20 @@ describe('mixpanelMiddleware', () => {
 
             it('formats all properties of payload', function() {
                 runMiddleware(mixpanelActionWithProps, {propertyFormatter: value => `===${value}===`});
+                assert.equal(mixpanel.track.firstCall.args[1]['===foo==='], 'bar');
+            });
+
+            it('formats all values of payload', function() {
+                runMiddleware(mixpanelActionWithProps, {valueFormatter: value => `===${value}===`});
+                assert.equal(mixpanel.track.firstCall.args[1]['foo'], '===bar===');
+            });
+
+            it('formats all properties and values of payload', function() {
+                runMiddleware(mixpanelActionWithProps, {
+                    propertyFormatter: value => `===${value}===`,
+                    valueFormatter: value => `===${value}===`
+                });
+
                 assert.equal(mixpanel.track.firstCall.args[1]['===foo==='], '===bar===');
             });
 


### PR DESCRIPTION
…g given to properties.

BREAKING CHANGE: Values will now, by default, remain unformatted when a `propertyFormatter` is given. To retain previous behaviour, apply the same `propertyFormatter` to `valueFormatter`.