### PR TITLE
fix(Increment): Follows mixpanel specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ const action = {
    meta: {
      mixpanel: {
          eventName: 'Some event',
-         increment: ['login'],
+         increment: ['login', 1], // or
+         increment: {'login': 1, 'logout': 2}, // or
+         increment: 'login'
      },
    },
 }

--- a/src/mixpanelMiddleware.js
+++ b/src/mixpanelMiddleware.js
@@ -52,7 +52,13 @@ export default function mixpanelMiddleware(token, options = {}) {
             mixpanel.time_event(timeEvent);
         }
 
-        if (increment && increment.length > 0) {
+        if (Array.isArray(increment)) {
+            mixpanel.people.increment(propertyFormatter(increment[0]), increment[1]);
+        } else if (increment === Object(increment)) {
+            mixpanel.people.increment(Object.keys(increment).reduce((inc, key) => ({ ...inc,
+                [propertyFormatter(key)]: increment[key],
+            }), {}));
+        } else if (increment) {
             mixpanel.people.increment(propertyFormatter(increment));
         }
 

--- a/test/mixpanelMiddleware.tests.js
+++ b/test/mixpanelMiddleware.tests.js
@@ -77,7 +77,7 @@ describe('mixpanelMiddleware', () => {
         },
     };
 
-    const mixpanelActionWithIncrement = {
+    const mixpanelActionWithIncrementArray = {
         type: 'Action',
         meta: {
             mixpanel: {
@@ -85,7 +85,36 @@ describe('mixpanelMiddleware', () => {
                 props: {
                     foo: 'bar',
                 },
-                increment: ['login'],
+                increment: ['login', 1],
+            },
+        },
+    };
+
+    const mixpanelActionWithIncrementObject = {
+        type: 'Action',
+        meta: {
+            mixpanel: {
+                eventName: 'fooEvent',
+                props: {
+                    foo: 'bar',
+                },
+                increment: {
+                    login: 1,
+                    logout: -1,
+                }
+            },
+        },
+    };
+
+    const mixpanelActionWithIncrementString = {
+        type: 'Action',
+        meta: {
+            mixpanel: {
+                eventName: 'fooEvent',
+                props: {
+                    foo: 'bar',
+                },
+                increment: 'login',
             },
         },
     };
@@ -210,10 +239,24 @@ describe('mixpanelMiddleware', () => {
             assert.equal(mixpanel.track.firstCall.args[1].action, 'Better Action');
         });
 
-        it('tracks an increment event with the provided values ', () => {
-            runMiddleware(mixpanelActionWithIncrement);
-            assert(mixpanel.people.increment.calledOnce);
-            assert(mixpanel.people.increment.calledWith(mixpanelActionWithIncrement.meta.mixpanel.increment));
+        describe('tracks an increment event with the provided values ', () => {
+            it('array', () => {
+                runMiddleware(mixpanelActionWithIncrementArray);
+                assert(mixpanel.people.increment.calledOnce);
+                assert(mixpanel.people.increment.calledWith(...mixpanelActionWithIncrementArray.meta.mixpanel.increment));
+            });
+
+            it('object', () => {
+                runMiddleware(mixpanelActionWithIncrementObject);
+                assert(mixpanel.people.increment.calledOnce);
+                assert(mixpanel.people.increment.calledWith(mixpanelActionWithIncrementObject.meta.mixpanel.increment));
+            });
+
+            it('object', () => {
+                runMiddleware(mixpanelActionWithIncrementString);
+                assert(mixpanel.people.increment.calledOnce);
+                assert(mixpanel.people.increment.calledWith(mixpanelActionWithIncrementString.meta.mixpanel.increment));
+            });
         });
 
         it('tracks timed event with the provided event name ', () => {
@@ -280,10 +323,27 @@ describe('mixpanelMiddleware', () => {
                 assert.equal(mixpanel.track.firstCall.args[1]['===foo==='], '===bar===');
             });
 
-            it('formats the increment name', function() {
-                runMiddleware(mixpanelActionWithIncrement, {propertyFormatter: value => `===${value}===`});
-                assert(mixpanel.people.increment.calledOnce);
-                assert(mixpanel.people.increment.calledWith('===login==='));
+            describe('formats the increment name', function() {
+                it('array', () => {
+                    runMiddleware(mixpanelActionWithIncrementArray, {propertyFormatter: value => `===${value}===`});
+                    assert(mixpanel.people.increment.calledOnce);
+                    assert(mixpanel.people.increment.calledWith('===login===', 1));
+                });
+
+                it('object', () => {
+                    runMiddleware(mixpanelActionWithIncrementObject, {propertyFormatter: value => `===${value}===`});
+                    assert(mixpanel.people.increment.calledOnce);
+                    assert(mixpanel.people.increment.calledWith({
+                        '===login===': 1,
+                        '===logout===': -1,
+                    }));
+                });
+
+                it('string', () => {
+                    runMiddleware(mixpanelActionWithIncrementString, {propertyFormatter: value => `===${value}===`});
+                    assert(mixpanel.people.increment.calledOnce);
+                    assert(mixpanel.people.increment.calledWith('===login==='));
+                });
             });
         });
     });


### PR DESCRIPTION
Follows [mixpanel specification](https://mixpanel.com/help/reference/javascript-full-api-reference#mixpanel.people.increment) of allowing either a String (with or without incremental/decremental value) or Object (for multiple increments/decrements). Property formatting is run over each increment key, whether it's and object or string.

