### PR TITLE
Fix middleware order

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "jsdom": "9.4.1",
     "jsdom-global": "2.0.0",
     "mocha": "2.5.3",
-    "sinon": "^1.17.5",
-    "semantic-release": "^6.3.6"
+    "semantic-release": "^6.3.6",
+    "sinon": "^3.2.1"
   },
   "dependencies": {
     "mixpanel-browser": "^2.8.1"

--- a/src/mixpanelMiddleware.js
+++ b/src/mixpanelMiddleware.js
@@ -34,6 +34,8 @@ export default function mixpanelMiddleware(token, options = {}) {
             } = {},
         } = action;
 
+        let result = next(action);
+
         if (eventName) {
             if (personSelector && uniqueIdSelector) {
                 const person = personSelector(store.getState());
@@ -62,6 +64,6 @@ export default function mixpanelMiddleware(token, options = {}) {
             mixpanel.people.increment(propertyFormatter(increment));
         }
 
-        return next(action);
+        return result;
     };
 }

--- a/test/mixpanelMiddleware.tests.js
+++ b/test/mixpanelMiddleware.tests.js
@@ -204,6 +204,10 @@ describe('mixpanelMiddleware', () => {
     }
 
     describe('middleware function', () => {
+        it('tracks actions after the next call', () => {
+            runMiddleware(mixpanelActionWithProps);
+            assert(nextStub.calledBefore(mixpanel.track));
+        });
 
         it('does not attempt to track an action with no meta', () => {
             runMiddleware(nonMixpanelAction);


### PR DESCRIPTION
This fixes an issue where it was difficult to track the arrival of profile data. Previously the mixpanel action was called before the redux data was stored making it impossible to retrieve the profile data.