### PR TITLE
fix(BabelConfig): Excluded from NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
+.babelrc
 /src
 /test


### PR DESCRIPTION
Removed `.babelrc` file from NPM package to not interfere with users build steps.